### PR TITLE
Always use `--script`

### DIFF
--- a/src/uvr/uvr.py
+++ b/src/uvr/uvr.py
@@ -12,7 +12,7 @@ def main():
     script = os.path.realpath(script)
     scriptDir = os.path.dirname(script)
 
-    os.execlp('uv', 'uv', 'run', '--project', scriptDir, script, *sys.argv[2:])
+    os.execlp('uv', 'uv', 'run', '--project', scriptDir, '--script', script, *sys.argv[2:])
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
This is necessary for scripts that lack a `.py` extension (and matches the existing behavior for scripts that have one).